### PR TITLE
Add label for "activities in the last year" count

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Features
 
-- **Recent Activity**: Showcases the latest public events from a specified GitHub user from 01/01/2024 -- 26/12/2024.
+- **Recent Activity**: Showcases the latest public events from a specified GitHub user in the past year 
 - **Responsive Design**: Ensures compatibility across various device sizes.
 - **Customizable**: Allows for styling adjustments to match your application's theme.
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+
+
 export default function Home() {
-  return <></>;
+  return <> </>;
 }

--- a/components/gh-activity-card.tsx
+++ b/components/gh-activity-card.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { ActivityCalendar } from "react-activity-calendar";
 import { twMerge } from "tailwind-merge";
 
+
 export default function GhActivityCard({
   username,
   className,
@@ -21,6 +22,8 @@ export default function GhActivityCard({
 }) {
   const [data, setData] = useState<null | []>(null);
   const [loading, setLoading] = useState<boolean>(false);
+  
+
   //eslint-disable-next-line
   const [_, setError] = useState<boolean>(false);
   useEffect(() => {
@@ -73,6 +76,9 @@ export default function GhActivityCard({
                   dark: ["#EBEDF0", "#9BE9A7", "#6CC565", "#58A250", "#3A6E3A"],
                 }
               }
+              labels={{
+                totalCount: "{{count}} activities in the last year",
+              }}
             />
           ) : (
             <p className={twMerge("text-white", errorClassName)}>
@@ -84,3 +90,5 @@ export default function GhActivityCard({
     </div>
   );
 }
+
+


### PR DESCRIPTION
## What this PR does  
Add a dynamic label to show the total activity count in the last year and not just a specific year.

## Changes  
- Added `labels` prop with `totalCount` set to `"{{count}} activities in the last year"`. 
- Adjust the README.md accordingly

## Context  
This improves user clarity by explicitly showing the timeframe ("last year") for the activity count instead of showing just a specific year.  

## Screenshot 
| Before | After |  
|---|---|  
| ![Before: Timeframe shows just 2024](<img width="706" alt="Before" src="https://github.com/user-attachments/assets/3bc7b7a0-fe21-48bb-a1f4-adf6f92293f2" />) |  ![After: Timeframe shows activities in the past year](<img width="800" alt="After" src="https://github.com/user-attachments/assets/b014544a-da1d-418c-8c8f-e4e462b92eae" />) |  
